### PR TITLE
Add tracking of order discounts and shipping costs incl tax

### DIFF
--- a/app/code/community/PiwikMage/PiwikAnalytics/Block/Piwik.php
+++ b/app/code/community/PiwikMage/PiwikAnalytics/Block/Piwik.php
@@ -30,7 +30,7 @@ class PiwikMage_PiwikAnalytics_Block_Piwik extends Mage_Core_Block_Template
      * Render information about specified orders and their items
      * http://piwik.org/docs/ecommerce-analytics/
      */
-    protected function _getOrdersTrackingCode()
+    protected function _getOrdersTrackingCode($shipping_include_taxes = false)
     {
         $orderIds = $this->getOrderIds();
         if (empty($orderIds) || !is_array($orderIds)) {
@@ -76,15 +76,22 @@ class PiwikMage_PiwikAnalytics_Block_Piwik extends Mage_Core_Block_Template
                 } else {
                     $subtotal = '0.00';
                 }
-                $result[] = sprintf("_paq.push(['trackEcommerceOrder' , '%s', %s, %s, %s, %s]);",
+
+                if($shipping_include_taxes) {
+                  $shipping = $order->getBaseShippingInclTax();
+                }
+                else {
+                  $shipping = $order->getBaseShippingAmount();
+                }
+
+                $result[] = sprintf("_paq.push(['trackEcommerceOrder' , '%s', %s, %s, %s, %s, %s]);",
                     $order->getIncrementId(),
                     $order->getBaseGrandTotal(),
                     $subtotal,
                     $order->getBaseTaxAmount(),
-                    $order->getBaseShippingAmount()
+                    $shipping,
+                    $order->getDiscountAmount()
                 );
-
-
             }
         }
         return implode("\n", $result);


### PR DESCRIPTION
This pull request adds:
- Tracking of order discounts
- Tracking of shippings costs including/excluding tax depending on the parameter $shipping_include_taxes

I think the first change makes sense, there may be some other people needing this.
The second change may be to custom.  But if someone else wants to see the shipping costs including tax in Piwik, he just has to replace _getOrdersTrackingCode() by _getOrdersTrackingCode(true) in his template.
