### PR TITLE
Fixing admin routers for SUPEE-6788

### DIFF
--- a/app/code/community/PiwikMage/PiwikAnalytics/controllers/Adminhtml/PiwikAnalytics/IndexController.php
+++ b/app/code/community/PiwikMage/PiwikAnalytics/controllers/Adminhtml/PiwikAnalytics/IndexController.php
@@ -11,7 +11,7 @@
  *
  */
 
-class PiwikMage_PiwikAnalytics_IndexController extends Mage_Adminhtml_Controller_Action
+class PiwikMage_PiwikAnalytics_Adminhtml_Piwikanalytics_IndexController extends Mage_Adminhtml_Controller_Action
 {
     public function indexAction()
     {

--- a/app/code/community/PiwikMage/PiwikAnalytics/etc/adminhtml.xml
+++ b/app/code/community/PiwikMage/PiwikAnalytics/etc/adminhtml.xml
@@ -21,7 +21,7 @@
                 <iframe_piwik translate="title" module="reports">
 					<title>Piwik iFrame</title>
 								<sort_order>99999</sort_order>
-								<action>piwikanalytics/index/index</action>
+								<action>adminhtml/piwikanalytics_index/index</action>
 							<depends><config>piwik/analytics/active</config></depends>
                 </iframe_piwik>
             </children>

--- a/app/code/community/PiwikMage/PiwikAnalytics/etc/config.xml
+++ b/app/code/community/PiwikMage/PiwikAnalytics/etc/config.xml
@@ -84,6 +84,15 @@
     </adminhtml>
     <admin>
         <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <piwikanalytics after="Mage_Adminhtml">PiwikMage_PiwikAnalytics_Adminhtml</piwikanalytics>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+        <routers>
             <PiwikMage_PiwikAnalytics>
                 <use>admin</use>
                 <args>


### PR DESCRIPTION
On security patch 6788, Magento updated security to use right way of
building admin routers. By this update, this module will works after
6788 security patch is applied.